### PR TITLE
Add Aurora address for PAD token

### DIFF
--- a/tokens/pad.json
+++ b/tokens/pad.json
@@ -1,6 +1,6 @@
 {
     "ethereum_address": "0xea7Cc765eBC94C4805e3BFf28D7E4aE48D06468A",
-    "aurora_address": "",
+    "aurora_address": "0x885f8CF6E45bdd3fdcDc644efdcd0AC93880c781",
     "name": "NearPad Token",
     "symbol": "PAD",
     "decimals": 18,


### PR DESCRIPTION
Pad token was deployed in Aurora in: https://explorer.mainnet.near.org/transactions/AEdoETgrvw7D2B2rQZYqVi6TBadcnabgnU2VWpXd6fom