### PR TITLE
Update DODO token metadata: add Aurora address

### DIFF
--- a/assets/aurora.tokenlist.json
+++ b/assets/aurora.tokenlist.json
@@ -27,7 +27,7 @@
       "description": "Tokens that were deployed initially on BSC. They have an equivalent token in NEAR and Aurora."
     }
   },
-  "timestamp": "2021-11-24T22:33:03+00:00",
+  "timestamp": "2021-12-09T00:36:50+00:00",
   "tokens": [
     {
       "chainId": 1313161554,
@@ -119,6 +119,28 @@
     },
     {
       "chainId": 1313161554,
+      "address": "0xe301ed8c7630c9678c39e4e45193d1e7dfb914f7",
+      "symbol": "DODO",
+      "name": "DODO bird",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/aurora-is-near/bridge-assets/master/tokens/dodo.svg",
+      "tags": [
+        "ethereum"
+      ]
+    },
+    {
+      "chainId": 1313161554,
+      "address": "0xea62791aa682d455614eaa2a12ba3d9a2fd197af",
+      "symbol": "FLX",
+      "name": "Flux Token",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/aurora-is-near/bridge-assets/master/tokens/flx.svg",
+      "tags": [
+        "ethereum"
+      ]
+    },
+    {
+      "chainId": 1313161554,
       "address": "0xda2585430fef327ad8ee44af8f1f989a2a91a3d2",
       "symbol": "FRAX",
       "name": "Frax",
@@ -199,6 +221,17 @@
       "name": "NearPad Token",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/aurora-is-near/bridge-assets/master/tokens/pad.svg",
+      "tags": [
+        "ethereum"
+      ]
+    },
+    {
+      "chainId": 1313161554,
+      "address": "0x8828a5047d093f6354e3fe29ffcb2761300dc994",
+      "symbol": "PULSE",
+      "name": "Pulse",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/aurora-is-near/bridge-assets/master/tokens/pulse.svg",
       "tags": [
         "ethereum"
       ]

--- a/tokens/dodo.json
+++ b/tokens/dodo.json
@@ -1,6 +1,6 @@
 {
   "ethereum_address": "0x43Dfc4159D86F3A37A5A4B3D4580b888ad7d4DDd",
-  "aurora_address": "",
+  "aurora_address": "0xe301ed8c7630c9678c39e4e45193d1e7dfb914f7",
   "name": "DODO bird",
   "symbol": "DODO",
   "decimals": 18,


### PR DESCRIPTION
* Add DODO ERC-20 address in Aurora: https://explorer.mainnet.aurora.dev/address/0xe301eD8C7630C9678c39E4E45193D1e7Dfb914f7
* Update tokens list