### PR TITLE
Add art arium to token list

### DIFF
--- a/tokens/art.json
+++ b/tokens/art.json
@@ -1,0 +1,11 @@
+{
+  "ethereum_address": "0x0F2Bb8aD44996A7762256477Fe3b42B27e63a00d",
+  "aurora_address": "",
+  "near_address": "0f2bb8ad44996a7762256477fe3b42b27e63a00d.factory.bridge.near",
+  "name": "Art Arium",
+  "symbol": "ART",
+  "decimals": 18,
+  "icon": "",
+  "reference": "",
+  "reference_hash": ""
+}


### PR DESCRIPTION
ERC-20: https://etherscan.io/address/0x0F2Bb8aD44996A7762256477Fe3b42B27e63a00d
NEP-141: https://explorer.mainnet.near.org/accounts/0f2bb8ad44996a7762256477fe3b42b27e63a00d.factory.bridge.near
Aurora ERC-20 (BlockScout): ART is a base token for the Arium Silo